### PR TITLE
Fix #page-projects to #projects

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -20,7 +20,7 @@
 
     I write high-quality, dependency-free, AI-free Rust libraries that help
     developers write code faster. You can see an overview of my projects
-    <a href="#page-projects">here</a> or
+    <a href="#projects">here</a> or
     <a
         href="https://github.com/bright-shard"
         target="_blank"


### PR DESCRIPTION
In pages/home.html, there is a redirect to the projects tab that directs to #page-projects when it should instead direct to just #projects